### PR TITLE
:tada: ユーザーが退室した時メッセージを返す機能を実装

### DIFF
--- a/backend/bot.rb
+++ b/backend/bot.rb
@@ -19,5 +19,20 @@ bot.voice_state_update do |event|
   end
 end
 
+# ユーザーが退室したときに返すメッセージのパターンを用意
+exit_messages = [
+  "またね、%{name} さん！",
+  "お疲れ様でした、%{name} さん！",
+  "また来てね、%{name} さん！",
+]
+
+# ユーザーが退室したときメッセージを返す
+bot.voice_state_update do |event|
+  # ユーザーが以前にいたチャンネル（event.old_channel）が存在し、ユーザーが現在いるチャンネル（event.channel）が存在しない場合にtrueになります。これは、ユーザーがボイスチャンネルから退出したときに該当します。
+  if event.old_channel && event.old_channel
+    event.user.pm(exit_messages.sample % {name: event.user.name})
+  end
+end
+
 # bot start
 bot.run


### PR DESCRIPTION
- [x] 退室時ダイレクトメッセージを返す
- [x] メッセージは3種類、ユーザーネーム付き

URLは未実装。
ユーザーページを作成する機能を追加したあとでないとURLは不明かと。