### PR TITLE
:tada: ヘッダー領域の確保と配色

### DIFF
--- a/frontend/app/src/App.js
+++ b/frontend/app/src/App.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Home from './Home';
+import Header from './Header';
 
 function App() {
   return (
     <Router>
+      <Header /> {/* Headerコンポーネントを挿入 */}
       <Routes>
-      	<Route path="/" element={<Home />} />
+          <Route path="/" element={<Home />} />
       </Routes>
     </Router>
   );

--- a/frontend/app/src/Header.js
+++ b/frontend/app/src/Header.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const Header = () => {
+  return (
+    <header className="text-center bg-discordPurple p-4">
+      <nav>
+        <ul className="flex justify-center space-x-4">
+          <li><a href="/" className="text-white">Home</a></li>
+          <li><a href="/about" className="text-white">About</a></li>
+          <li><a href="/contact" className="text-white">Contact</a></li>
+        </ul>
+      </nav>
+    </header>
+  );
+};
+
+export default Header;

--- a/frontend/app/tailwind.config.js
+++ b/frontend/app/tailwind.config.js
@@ -4,8 +4,12 @@ module.exports = {
     "./src/**/*.{js,jsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        discordPurple: '#7289DA',
+      }
+    },
   },
+  variants: {},
   plugins: [],
 }
-


### PR DESCRIPTION
- [x] ヘッダー領域の確保
- [x] Discordをイメージした配色

ヘッダーに追加したいカラムが思い浮かびません。
普通は新規登録やログインみたいなカラムを置くみたいですが、このアプリにはそれらは不要なので・・・。
いっそのことなしでも良いような気はします。
