### PR TITLE
:tada: ユーザーが退室した時にユーザーページのURLを返す機能の追加

### DIFF
--- a/backend/bot.rb
+++ b/backend/bot.rb
@@ -31,7 +31,11 @@ exit_messages = [
 bot.voice_state_update do |event|
   # ユーザーが以前にいたチャンネル（event.old_channel）が存在し、ユーザーが現在いるチャンネル（event.channel）が存在しない場合にtrueになります。これは、ユーザーがボイスチャンネルから退出したときに該当します。
   if event.old_channel && event.old_channel
-    event.user.pm(exit_messages.sample % {name: event.user.name})
+    # ユーザーが退室したときに、ユーザーページのURLをメッセージとともに送信する
+    user = User.find_by(name: event.user.name)
+    user_page_url = "http://localhost:3000/users/#{user.id}"
+    exit_message = exit_messages.sample % {name: event.user.name}
+    event.user.pm("#{exit_message} あなたのページはこちら: #{user_page_url}")
   end
 end
 


### PR DESCRIPTION
- [ ] 入室時にユーザーテーブルに保存されたユーザーネームからユーザーIDを取得し、そのユーザーのURLを返す

これはユーザーネームが固有のものであることが前提です。
[Discord公式](https://news.mynavi.jp/article/20230630-2713326/#:~:text=%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E5%90%8D%E3%81%AF%E5%9B%BA%E6%9C%89%E3%81%AE,%E3%80%81%E5%B0%8F%E6%96%87%E5%AD%97%E3%80%81%E9%9D%9E%E3%83%A9%E3%83%86%E3%83%B3%E6%96%87%E5%AD%97%E3%80%82)ではユーザーネームが固有であることが明言されているので問題ないかと思いますが。

![image](https://github.com/aiueo49/StudyTracer/assets/143853781/d2d1ae52-d476-464a-8f1d-b7af4997072d)

