### PR TITLE
[デプロイ後]バックエンドとフロントエンドを繋ぐその３

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -13,7 +13,7 @@ console_command = '/rails/bin/rails console'
   release_command = './bin/rails db:prepare'
 
 [http_service]
-  internal_port = 3000
+  internal_port = 8080
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true


### PR DESCRIPTION
- [x] fly.tomlのinternal_portを3000から8080に変更する

https://community.fly.io/t/app-doesnt-stop-instance-refused-connection-issues/14246