### PR TITLE
[デプロイ後]バックエンドとフロントエンドを繋ぐその５

### DIFF
--- a/backend/config/puma.rb
+++ b/backend/config/puma.rb
@@ -15,7 +15,7 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 8080 }
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
環境変数 `PORT` の値は、通常、アプリケーションが実行される環境（例えば、開発環境、テスト環境、本番環境）によって設定されます。これは特定のファイルに保存されるものではなく、アプリケーションが実行されるシステムやサービス（例えば、HerokuやAWSなど）によって設定されます。

しかし、ローカルの開発環境では、この値は `.env` ファイルやシェルの設定ファイル（例えば、`.bashrc` や `.zshrc`）に設定することがあります。これらのファイルは通常、プロジェクトのルートディレクトリやユーザーのホームディレクトリにあります。

また、Ruby on Rails の場合、`config/puma.rb` ファイル内で `PORT` 環境変数を参照して、Puma サーバーがリッスンするポートを設定することができます。あなたの `puma.rb` ファイルでは、`PORT` 環境変数が存在しない場合はデフォルトで `3000` ポートを使用するように設定されています。

```ruby
port ENV.fetch("PORT") { 3000 }
```

この行を以下のように変更すると、Puma サーバーは `8080` ポートでリッスンするようになります。

```ruby
port ENV.fetch("PORT") { 8080 }
```