### PR TITLE
デプロイテスト

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -18,6 +18,7 @@ Rails.application.configure do
   # 復活させる
   # Allow requests to studytracer-backend.fly.dev
   config.hosts << "studytracer-backend.fly.dev"
+  config.hosts << "localhost"
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).

--- a/backend/config/puma.rb
+++ b/backend/config/puma.rb
@@ -15,7 +15,7 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 8080 }
+port ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
Render.comにデプロイしたがエラーを吐いたので対処
```
Use Ctrl-C to stop
E, [2024-03-17T22:16:21.918306 #85] ERROR -- : [ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked hosts: localhost:10000
E, [2024-03-17T22:16:21.920360 #85] ERROR -- : [ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked hosts: localhost:8080
E, [2024-03-17T22:16:22.921014 #85] ERROR -- : [ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked hosts: localhost:10000
E, [2024-03-17T22:16:22.923656 #85] ERROR -- : [ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked hosts: localhost:8080
- Gracefully stopping, waiting for requests to finish
- Gracefully stopping, waiting for requests to finish
```

Rails 6以降では、`config.hosts`に許可されたホスト名を設定することで、ホスト名の検証が行われます。この設定がない場合、または設定されているホスト名とリクエストのホスト名が一致しない場合、`Blocked hosts`というエラーが発生します。

この問題を解決するには、`config/environments/production.rb`ファイル（または対応する環境設定ファイル）に以下のような設定を追加します：

```ruby
Rails.application.configure do
  # 他の設定...

  config.hosts << "localhost"
end
```

この設定は、`localhost`を許可されたホスト名のリストに追加します。必要に応じて、他のホスト名も追加できます。

設定を変更したら、アプリケーションを再起動して変更を適用します。